### PR TITLE
fix: resolve hydration error by using asChild on TooltipTrigger (prevents nested button markup)

### DIFF
--- a/renderer/components/main/navbar.tsx
+++ b/renderer/components/main/navbar.tsx
@@ -232,7 +232,7 @@ const Navbar = () => {
           <div className="wora-border flex w-18 flex-col items-center gap-10 rounded-2xl p-8">
             {navLinks.map((link) => (
               <Tooltip key={link.href} delayDuration={0}>
-                <TooltipTrigger>
+                <TooltipTrigger asChild>
                   <Button
                     variant="ghost"
                     className={isActive(link.href) && "opacity-100"}
@@ -253,7 +253,7 @@ const Navbar = () => {
             ))}
 
             <Tooltip delayDuration={0}>
-              <TooltipTrigger>
+              <TooltipTrigger asChild>
                 <Button variant="ghost" onClick={openSearch}>
                   <IconSearch stroke={2} className="w-5" />
                 </Button>
@@ -264,7 +264,7 @@ const Navbar = () => {
             </Tooltip>
           </div>
           <Tooltip delayDuration={0}>
-            <TooltipTrigger>
+            <TooltipTrigger asChild>
               <Button variant="ghost" onClick={handleThemeToggle}>
                 {renderIcon()}
               </Button>

--- a/renderer/components/main/player.tsx
+++ b/renderer/components/main/player.tsx
@@ -1151,7 +1151,7 @@ export const Player = () => {
 
                 <div className="flex">
                   <Tooltip delayDuration={0}>
-                    <TooltipTrigger>
+                    <TooltipTrigger asChild>
                       <Button
                         variant="ghost"
                         className="opacity-100! flex justify-center items-center"


### PR DESCRIPTION
fixes: hydration error with TooltipTrigger and nested button elements

- Updates TooltipTrigger usage across the Navbar and Player components to use `asChild`, preventing nested <button> markup.
- Resolves server/client hydration mismatch on SSR.
- Cleans up console warnings related to invalid HTML nesting.

No UI changes.  
No screenshots needed.